### PR TITLE
update:根据beta44版本，更新插件

### DIFF
--- a/lib/client/clientAppEnhance.js
+++ b/lib/client/clientAppEnhance.js
@@ -1,7 +1,9 @@
-import { defineClientAppEnhance } from '@vuepress/client';
-import AuroraArchive from "./components/AuroraArchive";
-import './style/aurora-archive.css'
+import { defineClientConfig } from '@vuepress/client';
+import AuroraArchive from './components/AuroraArchive.vue';
+import './style/aurora-archive.css';
 
-export default defineClientAppEnhance(({ app, router }) => {
-    app.component("AuroraArchive",AuroraArchive)
+export default defineClientConfig({
+    enhance({ app }) {
+        app.component('AuroraArchive', AuroraArchive);
+    }
 });

--- a/lib/node/vuepress-plugin-archive.js
+++ b/lib/node/vuepress-plugin-archive.js
@@ -37,7 +37,7 @@ const vuepressPluginArchive = ({ excludes,noTitle }) => {
         },
         name: 'vuepress-plugin-archive',
         multiple: false,
-        clientAppEnhanceFiles: utils_1.path.resolve(__dirname, '../client/clientAppEnhance.js')
+        clientConfigFile: utils_1.path.resolve(__dirname, '../client/clientAppEnhance.js')
     };
 };
 exports.archivePlugin = vuepressPluginArchive;


### PR DESCRIPTION
vuepress@beta44修改了一下core，插件无法使用了，徐亚哦修改
core: clientAppEnhanceFiles, clientAppRootComponentFiles and clientAppSetupFiles hooks are removed, use
clientConfigFile hook instead，